### PR TITLE
Update imports in examples

### DIFF
--- a/QuandaryWithPython_HowTo.ipynb
+++ b/QuandaryWithPython_HowTo.ipynb
@@ -28,6 +28,7 @@
    "source": [
     "#  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. \n",
     "from quandary import *\n",
+    "import numpy as np\n",
     "%matplotlib inline"
    ]
   },

--- a/example_cnot.py
+++ b/example_cnot.py
@@ -1,5 +1,6 @@
 #  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. 
 from quandary import * 
+import numpy as np
 
 ## Two qubit test case: CNOT gate, two levels each, no guard levels, dipole-dipole coupling 5KHz ##
 

--- a/example_cnot_withguardlevels.py
+++ b/example_cnot_withguardlevels.py
@@ -1,5 +1,6 @@
 #  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. 
 from quandary import * 
+import numpy as np
 
 ## Two qubit test case: CNOT gate, two levels each, 1 or 2 guard levels, dipole-dipole coupling 5MHz ##
 Ne = [2, 2]

--- a/example_piecewise_constant_controls.py
+++ b/example_piecewise_constant_controls.py
@@ -1,5 +1,6 @@
 #  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. 
 from quandary import * 
+import numpy as np
 
 ## Two qubit test case, demonstrating the use of piecewise constant control functions with total variation penalty term. CNOT gate, two levels each, no guard levels, dipole-dipole coupling 5KHz ##
 

--- a/example_qft.py
+++ b/example_qft.py
@@ -1,5 +1,6 @@
 #  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. 
 from quandary import * 
+import numpy as np
 
 ## QFT gates on qubit chain, two levels, no guard levels, dipole-dipole coupling 5KHz (chain topology) ##
 

--- a/example_spinchain.py
+++ b/example_spinchain.py
@@ -1,5 +1,8 @@
 #  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. 
 from quandary import * 
+import numpy as np
+import matplotlib.pyplot as plt
+
 np.random.seed(9001)
 
 ### Define some case's coefficients

--- a/example_state_to_state.py
+++ b/example_state_to_state.py
@@ -1,5 +1,6 @@
 #  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. 
 from quandary import * 
+import numpy as np
 
 ## One qudit test case: State preparation (state-to-state) of the GHZ state ##
 

--- a/example_swap12.py
+++ b/example_swap12.py
@@ -1,5 +1,6 @@
 #  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. 
 from quandary import * 
+import numpy as np
 
 ## Two qubit test case for the SWAP gate, two essential levels each, no guard levels ##
 

--- a/optimize_then_perturb_controls.py
+++ b/optimize_then_perturb_controls.py
@@ -1,5 +1,6 @@
 #  Quandary's python interface functions are defined in /path/to/quandary/quandary.py. Import them here. 
 from quandary import * 
+import numpy as np
 
 ## Two qubit test case, demonstrating the use of piecewise constant control functions with total variation penalty term. It also demonstrates how to perturb the control vector and evaluate the corresponding fidelity.
 # Here, the qubits have two levels each, no guard levels, with a dipole-dipole coupling 5MHz ##


### PR DESCRIPTION
As part of the work on the new python interface (https://github.com/llnl/quandary/pull/114), I want to package both the new and old interfaces, which requires adding an `__init__.py`. I want to make sure the examples still work correctly, so I am adding explicit imports for numpy and matplotlib.

- Before (no` __init__.py`):                                                                              
  `from quandary import *` imported directly from quandary.py, which has import numpy as np at the top.   
  import * pulls the entire module namespace, including np.                                             
                                                                                                        
- Now (or soon) (with `__init__.py`):                                                                               
  quandary is a package. `from quandary import *` imports from `__init__.py`, which only exports what's     
  explicitly listed in `__all__`. We don't re-export np there.  