### PR TITLE
Replace cfg with toml

### DIFF
--- a/QuandaryWithPython_HowTo.ipynb
+++ b/QuandaryWithPython_HowTo.ipynb
@@ -49,7 +49,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Executing ' mpirun -np  3 quandary ./config.cfg --quiet . Runtype:  optimization ...\n",
+      "Executing ' mpirun -np  3 quandary ./config.toml --quiet . Runtype:  optimization ...\n",
       "    Objective             Tikhonov                Penalty-Leakage        Penalty-StateVar       Penalty-TotalEnergy    Penalty-CtrlVar\n",
       "0  9.01413770665704e-01 + 1.14880994107351e-06 + 4.92008024113254e-05 + 1.59677761749278e-06 + 1.82940089620197e-05 + 0.00000000000000e+00  Fidelity = 9.85862293342961e-02  ||Grad|| = 3.02938565436338e-01\n",
       "1  4.46562869956035e-01 + 1.09663002122803e-06 + 1.53556555689983e-05 + 2.13023995821287e-06 + 2.83396267611865e-05 + 0.00000000000000e+00  Fidelity = 5.53437130043965e-01  ||Grad|| = 4.82739122708045e-01\n",
@@ -217,9 +217,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Executing ' mpirun -np  3 quandary ./config.cfg --quiet . Runtype:  simulation ...\n",
+      "Executing ' mpirun -np  3 quandary ./config.toml --quiet . Runtype:  simulation ...\n",
       "Fidelity =  0.999916180161363\n",
-      "Executing ' mpirun -np  3 quandary ./config.cfg --quiet . Runtype:  simulation ...\n",
+      "Executing ' mpirun -np  3 quandary ./config.toml --quiet . Runtype:  simulation ...\n",
       "Fidelity =  0.999912289800873\n"
      ]
     }
@@ -254,7 +254,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Executing ' mpirun -np  1 quandary ./config.cfg --quiet . Runtype:  evalcontrols ...\n"
+      "Executing ' mpirun -np  1 quandary ./config.toml --quiet . Runtype:  evalcontrols ...\n"
      ]
     },
     {
@@ -448,7 +448,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Executing ' mpirun -np  1 quandary ./config.cfg --quiet . Runtype:  optimization ...\n",
+      "Executing ' mpirun -np  1 quandary ./config.toml --quiet . Runtype:  optimization ...\n",
       "    Objective             Tikhonov                Penalty-Leakage        Penalty-StateVar       Penalty-TotalEnergy    Penalty-CtrlVar\n",
       "0  5.02049583478701e-01 + 2.56090704561570e-10 + 0.00000000000000e+00 + 9.01784421151395e-15 + 8.98449028423572e-09 + 0.00000000000000e+00  Fidelity = 4.97950416521299e-01  ||Grad|| = 1.33055979431340e-01\n",
       "1  4.62265425914091e-02 + 1.73742095334636e-07 + 0.00000000000000e+00 + 1.24752998393009e-09 + 1.00933850676236e-05 + 0.00000000000000e+00  Fidelity = 9.53773457408591e-01  ||Grad|| = 3.24748385751329e-01\n",
@@ -506,7 +506,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Executing ' mpirun -np  2 quandary ./config.cfg --quiet . Runtype:  simulation ...\n",
+      "Executing ' mpirun -np  2 quandary ./config.toml --quiet . Runtype:  simulation ...\n",
       "Test fidelity =  0.9999983222139354\n"
      ]
     }
@@ -576,7 +576,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Executing ' mpirun -np  1 quandary ./config.cfg --quiet . Runtype:  optimization ...\n",
+      "Executing ' mpirun -np  1 quandary ./config.toml --quiet . Runtype:  optimization ...\n",
       "    Objective             Tikhonov                Penalty-Leakage        Penalty-StateVar       Penalty-TotalEnergy    Penalty-CtrlVar\n",
       "0  5.04302153193254e-01 + 2.10627618973362e-10 + 7.68884448559118e-13 + 1.30073858299733e-14 + 6.26929913180880e-09 + 0.00000000000000e+00  Fidelity = 4.95697846806746e-01  ||Grad|| = 1.06633467203195e-01\n",
       "1  4.72015038447107e-02 + 1.74549639007923e-07 + 2.92029258595263e-06 + 1.65120445024727e-09 + 1.01403330272047e-05 + 0.00000000000000e+00  Fidelity = 9.52798496155289e-01  ||Grad|| = 2.87426078195549e-01\n",
@@ -585,10 +585,10 @@
       "Optimization converged with small final time cost.\n",
       "\n",
       "Optimized Fidelity = 0.999985110181464\n",
-      "Executing ' mpirun -np  1 quandary ./config.cfg --quiet . Runtype:  simulation ...\n",
+      "Executing ' mpirun -np  1 quandary ./config.toml --quiet . Runtype:  simulation ...\n",
       "\n",
       "Fidelity under noise = 0.999771006775087\n",
-      "Executing ' mpirun -np  1 quandary ./config.cfg --quiet . Runtype:  optimization ...\n",
+      "Executing ' mpirun -np  1 quandary ./config.toml --quiet . Runtype:  optimization ...\n",
       "    Objective             Tikhonov                Penalty-Leakage        Penalty-StateVar       Penalty-TotalEnergy    Penalty-CtrlVar\n",
       "0  2.28993224913099e-04 + 1.07258244109532e-07 + 2.43336388444282e-11 + 0.00000000000000e+00 + 6.22907730287354e-06 + 0.00000000000000e+00  Fidelity = 9.99771006775087e-01  ||Grad|| = 6.13164245554497e-02\n",
       "1  2.26078220585180e-04 + 1.06806858565545e-07 + 2.39668918007565e-11 + 0.00000000000000e+00 + 6.20290239183761e-06 + 0.00000000000000e+00  Fidelity = 9.99773921779415e-01  ||Grad|| = 1.20347930207001e-02\n",
@@ -740,7 +740,7 @@
     "#     - Set 'verbose=True' when constructing the Quandary object. Inspect the output, in particular the selected carrier wave frequencies. Do they make sense for your target gate?\n",
     "#     - Increase the number of iterations (maxiter)\n",
     "#     - Increase the number of Bspline basis functions (increase nsplines, or decrease spline_knot_spacing)\n",
-    "#     - Inspect the files written to './run_dir/' (or the user-defined alternative output directory). In particular config.cfg, targetgate/state.dat.\n",
+    "#     - Inspect the files written to './run_dir/' (or the user-defined alternative output directory). In particular config.toml, targetgate/state.dat.\n",
     "\n",
     "# * What to do if the results don't match to other software, or to my expectations?\n",
     "#     - Turn on 'verbose=True' and check screen output of quandary.simulate(). Anything suspicious?\n",

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ See [Quandary](https://github.com/LLNL/quandary) for instructions on running thr
 Gate optimization CNOT:
   * Optimizes for a CNOT gate on two coupled qubits each modelled with 2 energy levels. 
   * T = 200ns, time step size = 0.1ns
-  * 'cnot.cfg': Runs a closed-system (Schroedinger eq.) optimization using random initial control parameters. Can be run on up to 4 cores (one for each initial basis state)
-  * 'cnot_FWD_optimized.cfg': Evaluates the fidelity of the control parameters stored in 'params_optimized.dat' by forward simulation (Schroedinger's equation)
-  * 'cnot_FWD_optimized_withnoise.cfg': Same as above, but simulates with Lindblads master equation (with decoherence). 
+  * 'cnot.toml': Runs a closed-system (Schroedinger eq.) optimization using random initial control parameters. Can be run on up to 4 cores (one for each initial basis state)
+  * 'cnot_FWD_optimized.toml': Evaluates the fidelity of the control parameters stored in 'params_optimized.dat' by forward simulation (Schroedinger's equation)
+  * 'cnot_FWD_optimized_withnoise.toml': Same as above, but simulates with Lindblads master equation (with decoherence). 
 
 Gate optimization SWAP02:
   * Considers a qudid modelled with 3 essential energy levels and one guard level


### PR DESCRIPTION
Replace cfg with toml in README and notebook outputs. We already removed .cfg example files.